### PR TITLE
docs: professionalize project READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Set at least the following variables in `apps/backend/.env`:
 ```env
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/mydb"
 JWT_SECRET="replace-with-a-strong-secret"
-PORT=3000
+PORT=4000
 ```
 
 Then start the backend:
@@ -70,9 +70,9 @@ bun install
 bun run start:dev
 ```
 
-Backend default URL: `http://localhost:3000`
+Backend URL in this setup: `http://localhost:4000`
 
-Swagger docs: `http://localhost:3000/api/v1/docs`
+Swagger docs: `http://localhost:4000/api/v1/docs`
 
 ### 4) Run frontend
 
@@ -86,7 +86,7 @@ bun install
 Create `apps/frontend/.env.local`:
 
 ```env
-NEXT_PUBLIC_API_URL="http://localhost:3000"
+NEXT_PUBLIC_API_URL="http://localhost:4000"
 ```
 
 Start the frontend:
@@ -131,6 +131,5 @@ From `apps/frontend`:
 <a href="https://github.com/garma-a/qc_project/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=garma-a/qc_project" alt="Contributors" />
 </a>
-
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ AHC QC Project is a laboratory quality control platform built as a monorepo with
 - Swagger API documentation for backend endpoints
 - Modern dashboard UX for login, monitor, QC history, users, and alerts
 
+## Backend-Centric Scope
+
+This project is designed around backend reliability for laboratory operations:
+
+- clear domain boundaries in the API layer
+- validation and role-guarded endpoints
+- relational modeling for QC auditability
+- alert-state lifecycle for operational follow-up
+
 ## Tech Stack
 
 - Backend: NestJS 11, Drizzle ORM, PostgreSQL, JWT, Swagger
@@ -97,6 +106,18 @@ bun run dev
 
 Frontend default URL: `http://localhost:3000` (Next.js)
 
+## API Domains (Backend)
+
+Main backend modules exposed under `/api/v1`:
+
+- `auth` - login and token issuance
+- `users` - role-protected user management
+- `machines` - machine registration and updates
+- `qc-tests` - test definitions by machine
+- `control-lots` - lot metadata and target ranges
+- `qc-results` - measured values and status computation
+- `alerts` - alert retrieval and resolution workflow
+
 ## Optional: Seed Demo Data
 
 From `apps/backend`:
@@ -106,6 +127,12 @@ bun run seed
 ```
 
 The seed script creates users and prints demo credentials in the terminal.
+
+## Troubleshooting
+
+- If frontend requests fail, verify `NEXT_PUBLIC_API_URL` points to the backend port you actually run.
+- If backend fails to connect, verify PostgreSQL is up and `DATABASE_URL` matches your local container config.
+- If auth-protected calls return `401`, ensure login succeeded and token is included in requests.
 
 ## Useful Commands
 
@@ -131,5 +158,4 @@ From `apps/frontend`:
 <a href="https://github.com/garma-a/qc_project/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=garma-a/qc_project" alt="Contributors" />
 </a>
-
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,136 @@
-## AHC QC Project Documentation
+# AHC QC Project
 
+AHC QC Project is a laboratory quality control platform built as a monorepo with a NestJS backend and a Next.js frontend. It centralizes machine monitoring, QC execution, control-lot management, and alert workflows for lab teams.
 
-### How to run this project on your machine
+## Repository Structure
 
-1. **Clone the Repository**: Start by cloning the repository to your local machine using the following command:
-   ```
-   git clone <repository_url>
-   ```
-2. **Navigate to the Project Directory**: Change your current directory to the project folder:
-   ```
-   cd <project_directory>
-   ```
-3. **Install Dependencies for the backend**:
-```sh
+```text
+.
+|-- apps/
+|   |-- backend/    # NestJS API + Drizzle/PostgreSQL
+|   `-- frontend/   # Next.js dashboard
+|-- docker-compose.yml
+`-- Dockerfile
+```
+
+## Key Capabilities
+
+- Role-aware authentication and authorization (ADMIN, TECHNICIAN)
+- QC data lifecycle: machines, tests, control lots, and QC results
+- Alerting workflow with seen/resolved state tracking
+- Swagger API documentation for backend endpoints
+- Modern dashboard UX for login, monitor, QC history, users, and alerts
+
+## Tech Stack
+
+- Backend: NestJS 11, Drizzle ORM, PostgreSQL, JWT, Swagger
+- Frontend: Next.js 16, React 19, TypeScript, Zustand, Recharts
+- Runtime: Bun
+- Infra: Docker and Docker Compose for local services
+
+## Prerequisites
+
+- Bun 1.0+
+- Docker (recommended for PostgreSQL)
+
+## Quick Start
+
+### 1) Clone the repository
+
+```bash
+git clone https://github.com/garma-a/QC_project.git
+cd QC_project
+```
+
+### 2) Start PostgreSQL
+
+```bash
+docker compose up -d db
+```
+
+### 3) Run backend
+
+```bash
 cd apps/backend
-npm ci
-npm run start:dev
+cp .env-example .env
 ```
 
+Set at least the following variables in `apps/backend/.env`:
 
-3. **Install Dependencies for the frontend**:
-```sh
+```env
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/mydb"
+JWT_SECRET="replace-with-a-strong-secret"
+PORT=3000
+```
+
+Then start the backend:
+
+```bash
+bun install
+bun run start:dev
+```
+
+Backend default URL: `http://localhost:3000`
+
+Swagger docs: `http://localhost:3000/api/v1/docs`
+
+### 4) Run frontend
+
+In a new terminal:
+
+```bash
 cd apps/frontend
-npm ci
-npm run dev
+bun install
 ```
 
-### Thanks for the Amazing team
+Create `apps/frontend/.env.local`:
+
+```env
+NEXT_PUBLIC_API_URL="http://localhost:3000"
+```
+
+Start the frontend:
+
+```bash
+bun run dev
+```
+
+Frontend default URL: `http://localhost:3000` (Next.js)
+
+## Optional: Seed Demo Data
+
+From `apps/backend`:
+
+```bash
+bun run seed
+```
+
+The seed script creates users and prints demo credentials in the terminal.
+
+## Useful Commands
+
+From repository root:
+
+- `npm run docker:up` - build and start local containers
+- `npm run docker:down` - stop containers
+
+From `apps/backend`:
+
+- `bun run start:dev` - run API in watch mode
+- `bun run test` - run tests
+- `bun run build` - compile production build
+
+From `apps/frontend`:
+
+- `bun run dev` - run Next.js app locally
+- `bun run build` - build frontend
+- `bun run lint` - lint frontend code
+
+## Contributors
 
 <a href="https://github.com/garma-a/qc_project/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=garma-a/qc_project" />
+  <img src="https://contrib.rocks/image?repo=garma-a/qc_project" alt="Contributors" />
 </a>
-
 
 
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,25 +1,92 @@
-Project Description
+# AHC QC Backend
 
-Backend system built with NestJS implementing JWT authentication, role-based access control, and soft delete for users.
+NestJS backend for the AHC QC platform. This service provides authentication, role-based access, QC domain APIs, and alert workflows for laboratory quality control operations.
 
-Features
+## What This Service Covers
 
-JWT authentication
+- JWT-based authentication
+- Role-based authorization (`ADMIN`, `TECHNICIAN`)
+- QC domain modules for machines, tests, control lots, and results
+- Alert state transitions (`UNSEEN`, `SEEN`, `RESOLVED`)
+- OpenAPI/Swagger documentation
 
-Role-based authorization (ADMIN / INTERN)
+## Stack
 
-Soft delete (isActive flag)
+- NestJS 11
+- Drizzle ORM + PostgreSQL
+- Passport JWT
+- Argon2 password hashing
+- Bun runtime/tooling
 
-Secure login validation
+## Project Modules
 
-Password hashing with Argon2
+- `auth` - login and token issuance
+- `users` - user management and role-protected operations
+- `machines` - machine CRUD and status context
+- `qc-tests` - test definitions per machine
+- `control-lots` - lot metadata and QC thresholds
+- `qc-results` - measured QC runs and status evaluation
+- `alerts` - alert retrieval and acknowledgement workflow
 
+## API Base and Docs
 
-JWT_SECRET=your_secret_here
-DATABASE_URL=your_database_url
-ADMIN_EMAIL=
-ADMIN_PASSWORD=
+- Base path: `/api/v1`
+- Swagger UI: `/api/v1/docs`
 
-How to Run
-npm install
-npm run start:dev
+By default, local server URL is `http://localhost:3000`.
+
+## Environment Variables
+
+Create `.env` in this directory:
+
+```env
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/mydb"
+JWT_SECRET="replace-with-a-strong-secret"
+PORT=3000
+```
+
+Notes:
+
+- `DATABASE_URL` is used by Drizzle.
+- `JWT_SECRET` is required for token signing and verification.
+- `PORT` is optional (defaults to `3000`).
+
+## Local Development
+
+### 1) Install dependencies
+
+```bash
+bun install
+```
+
+### 2) Start PostgreSQL (from repo root)
+
+```bash
+docker compose up -d db
+```
+
+### 3) Run backend in watch mode
+
+```bash
+bun run start:dev
+```
+
+## Seed Data
+
+To populate demo QC data:
+
+```bash
+bun run seed
+```
+
+The script creates sample users, machines, tests, control lots, and results, then prints login emails in the terminal.
+
+## Commands
+
+- `bun run start:dev` - development server with watch mode
+- `bun run start:prod` - run compiled server
+- `bun run build` - compile backend
+- `bun run test` - run test suite
+- `bun run test:cov` - coverage run
+- `bun run lint` - lint code
+- `bun run seed` - seed demo data

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -10,6 +10,14 @@ NestJS backend for the AHC QC platform. This service provides authentication, ro
 - Alert state transitions (`UNSEEN`, `SEEN`, `RESOLVED`)
 - OpenAPI/Swagger documentation
 
+## Backend Responsibilities
+
+- enforce request validation and payload contracts
+- protect routes via auth guards and role checks
+- persist QC entities and relationships in PostgreSQL
+- evaluate QC results and expose alert workflows
+- provide stable APIs for frontend dashboards
+
 ## Stack
 
 - NestJS 11
@@ -90,3 +98,12 @@ The script creates sample users, machines, tests, control lots, and results, the
 - `bun run test:cov` - coverage run
 - `bun run lint` - lint code
 - `bun run seed` - seed demo data
+
+## Suggested Backend Validation Flow
+
+After startup, validate core behavior in this order:
+
+1. Open Swagger and verify API docs load.
+2. Execute login request and obtain token.
+3. Call one protected endpoint with Bearer token.
+4. Create/read one QC domain entity (machine/test/lot/result).

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -42,14 +42,14 @@ Create `.env` in this directory:
 ```env
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/mydb"
 JWT_SECRET="replace-with-a-strong-secret"
-PORT=3000
+PORT=4000
 ```
 
 Notes:
 
 - `DATABASE_URL` is used by Drizzle.
 - `JWT_SECRET` is required for token signing and verification.
-- `PORT` is optional (defaults to `3000`).
+- `PORT` is optional (defaults to `3000`). Use `4000` for local full-stack runs to avoid clashing with Next.js.
 
 ## Local Development
 

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -11,6 +11,15 @@ Next.js dashboard for the AHC QC platform. The frontend provides authenticated w
 - Alerts inbox and resolution actions
 - User management (admin)
 
+## Backend Integration Focus
+
+This frontend is primarily an API consumer for backend workflows:
+
+- authenticated requests to protected endpoints
+- QC entity creation/update flows via server actions
+- dashboard rendering from backend datasets
+- alert acknowledgement and resolution actions
+
 ## Stack
 
 - Next.js 16 + React 19

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -25,12 +25,16 @@ The UI calls backend endpoints under `/api/v1/*` through shared helpers in `src/
 
 Default backend fallback URL is `http://localhost:3000`, and can be overridden using an environment variable.
 
+For local full-stack development, running backend on `4000` is recommended to avoid port collision with Next.js.
+
+Important: the frontend currently defaults internally to `http://localhost:3000` when `NEXT_PUBLIC_API_URL` is not set.
+
 ## Environment
 
 Create `apps/frontend/.env.local`:
 
 ```env
-NEXT_PUBLIC_API_URL="http://localhost:3000"
+NEXT_PUBLIC_API_URL="http://localhost:4000"
 ```
 
 ## Run Locally

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,36 +1,58 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# AHC QC Frontend
 
-## Getting Started
+Next.js dashboard for the AHC QC platform. The frontend provides authenticated workflows for laboratory monitoring, QC history analysis, alert handling, and user administration.
 
-First, run the development server:
+## Main Screens
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+- Login
+- Dashboard overview
+- Machine monitor view
+- QC history and submission flows
+- Alerts inbox and resolution actions
+- User management (admin)
+
+## Stack
+
+- Next.js 16 + React 19
+- TypeScript
+- Zustand for client-side state
+- Recharts for data visualization
+- Tailwind CSS
+
+## API Integration
+
+The UI calls backend endpoints under `/api/v1/*` through shared helpers in `src/lib/api`.
+
+Default backend fallback URL is `http://localhost:3000`, and can be overridden using an environment variable.
+
+## Environment
+
+Create `apps/frontend/.env.local`:
+
+```env
+NEXT_PUBLIC_API_URL="http://localhost:3000"
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Run Locally
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+bun install
+bun run dev
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Open `http://localhost:3000`.
 
-## Learn More
+## Scripts
 
-To learn more about Next.js, take a look at the following resources:
+- `bun run dev` - start Next.js dev server
+- `bun run build` - production build
+- `bun run start` - run production build
+- `bun run lint` - run linter
+- `bun run dev:vinext` - run Vinext/Vite dev mode (experimental)
+- `bun run build:vinext` - build Vinext/Vite mode
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Suggested Local Workflow
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+1. Start backend from `apps/backend`.
+2. Start frontend from this directory.
+3. Sign in using seeded credentials from backend seeding output.


### PR DESCRIPTION
## Summary
- Rewrite the root README with a production-style overview, architecture, setup, and workflow guidance.
- Replace backend/frontend README files with focused documentation for environment variables, scripts, API/docs links, and local run instructions.
- Clarify local full-stack port configuration (`4000` backend + `3000` frontend) and document seeding flow for easier onboarding.