### PR TITLE
move to local DB with connection thread poll

### DIFF
--- a/apps/backend/.env-example
+++ b/apps/backend/.env-example
@@ -1,1 +1,7 @@
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/mydb"
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=qc_project
+DB_USER=postgres
+DB_PASSWORD=postgres
+
+JWT_SECRET="your-jwt-secret-here"

--- a/apps/backend/drizzle.config.ts
+++ b/apps/backend/drizzle.config.ts
@@ -1,11 +1,25 @@
 import { defineConfig } from 'drizzle-kit';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const host = process.env.DB_HOST ?? 'localhost';
+const port = process.env.DB_PORT ?? '5432';
+const database = process.env.DB_NAME ?? 'qc_project';
+const user = process.env.DB_USER ?? 'postgres';
+const password = process.env.DB_PASSWORD ?? 'postgres';
 
 export default defineConfig({
   schema: './src/drizzle/schema.ts',
   out: './drizzle',
   dialect: 'postgresql',
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    host,
+    port: parseInt(port, 10),
+    database,
+    user,
+    password,
+    ssl: false,
   },
   verbose: true,
   strict: true,

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,7 +20,9 @@
         "test:watch": "bun test --watch",
         "test:cov": "bun test --coverage",
         "test:e2e": "bun test ./test",
-"seed": "ts-node -r tsconfig-paths/register src/database/seed.ts"
+        "seed": "ts-node -r tsconfig-paths/register src/database/seed.ts",
+        "db:migrate": "bunx drizzle-kit migrate",
+        "db:seed": "bun --bun ts-node -r tsconfig-paths/register src/database/seed.ts"
     },
     "dependencies": {
         "@neondatabase/serverless": "^1.0.2",

--- a/apps/backend/src/database/database.service.ts
+++ b/apps/backend/src/database/database.service.ts
@@ -1,27 +1,58 @@
-import { drizzle, NeonHttpDatabase } from 'drizzle-orm/neon-http';
-import { neon } from '@neondatabase/serverless';
-
+import { drizzle, NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
 
 import * as schema from '../drizzle/schema';
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleDestroy, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
-export class DatabaseService {
-  public readonly db: NeonHttpDatabase<typeof schema>;
+export class DatabaseService implements OnModuleDestroy {
+  public readonly db: NodePgDatabase<typeof schema>;
+  private readonly pool: Pool;
+  private readonly logger = new Logger(DatabaseService.name);
 
   constructor(private configService: ConfigService) {
-    const databaseUrl = this.configService.get<string>('DATABASE_URL');
+    const host = this.configService.get<string>('DB_HOST') ?? 'localhost';
+    const port = parseInt(this.configService.get<string>('DB_PORT') ?? '5432', 10);
+    const database = this.configService.get<string>('DB_NAME');
+    const user = this.configService.get<string>('DB_USER');
+    const password = this.configService.get<string>('DB_PASSWORD');
 
-    if (!databaseUrl) {
-      throw new Error('DATABASE_URL is missing!');
+    if (!database || !user || !password) {
+      throw new Error(
+        'Missing required DB environment variables: DB_NAME, DB_USER, DB_PASSWORD',
+      );
     }
 
-    // Use the standard postgres driver for local development
-    const sql = neon(databaseUrl);
-    this.db = drizzle(sql, { schema });
+    this.pool = new Pool({
+      host,
+      port,
+      database,
+      user,
+      password,
+      max: 100,              // Maximum number of connections
+      min: 5,               // Minimum idle connections to keep open
+      idleTimeoutMillis: 30000,      // Close idle connections after 30 seconds
+      connectionTimeoutMillis: 2000, // Error out if waiting in queue for > 2 seconds
+      maxUses: 7500,         // Close a connection after 7500 uses (prevents memory leaks)
+    });
 
+    this.pool.on('error', (err) => {
+      this.logger.error('Unexpected error on idle client', err);
+    });
 
+    this.pool.on('connect', () => {
+      this.logger.debug('New client connected to the pool');
+    });
 
+    this.db = drizzle(this.pool, { schema });
+
+    this.logger.log(`Database pool initialised → ${host}:${port}/${database}`);
+  }
+
+  async onModuleDestroy() {
+    this.logger.log('Draining database pool...');
+    await this.pool.end();
+    this.logger.log('Database pool closed.');
   }
 }


### PR DESCRIPTION
   Mode                                 │ Req/Sec     │ Latency     │ Notes
  ──────────────────────────────────────┼─────────────┼─────────────┼─────────────────────────────────────────
    ?limit=50&offset=0  ← correct usage │ 120         │ 413ms       │ ✅ Same as other endpoints
   No params (bare  /qc-results )       │ 1.67        │ 6808ms      │ 🔴 Full 4185-row dump — never call this
    ?lotId=1 				│ 91          │ 538ms       │ ✅ Good — returns lot's history
  ──────
  ## ✅ Updated Full Report
  
   Endpoint                            │ Req/Sec                           │ Status
  ─────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────
    GET /sections                      │ 133                               │ 🟢 13x Neon
    GET /machines                      │ 121                               │ 🟢 12x Neon
    GET /qc-results?limit=50&offset=0  │ 120                               │ 🟢 12x Neon
    GET /machines/:id                  │ 126                               │ 🟢 13x Neon
    GET /users                         │ 82                                │ 🟢 8x Neon
    GET /alerts                        │ 19                                │ 🟡 2x Neon
    POST /auth/login                   │ 5.5                               │ 🔴 CPU-bound (argon2, by design)
    GET /qc-results  (no params)       │ 1.67                              │ 🔴 Should never be called bare
  
  The only real remaining bottleneck is  /alerts  at 19 req/sec — that one genuinely has no pagination and    
  returns heavy joined data. Want me to fix that next?